### PR TITLE
Fix import errors

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -44,6 +44,11 @@ include-package-data = true
 [tool.setuptools.packages.find]
 where = ["."]
 
+[tool.setuptools.package-data]
+webeyetrack = [
+    "model_weights/*",
+]
+
 [tool.ruff]
 ignore = ["E501"]
 select = ["E", "W", "F", "C", "B", "I"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = 'MIT'
 readme = "README.md"
-requires-python = ">3.6"
+requires-python = ">=3.9, <3.13" # mediapipe requires 3.9-3.12
 
 keywords = ["eye-tracking", "scalable", "rgb", "gaze"]
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     'mediapipe',
     'numpy',
     "opencv-python",
-    "scipy"
+    "scipy",
+    "tensorflow",
 ]
 
 [project.optional-dependencies]

--- a/python/webeyetrack/constants.py
+++ b/python/webeyetrack/constants.py
@@ -1,8 +1,8 @@
 import pathlib
 import numpy as np
 
-GIT_ROOT = pathlib.Path(__file__).parent.parent.parent
-PACKAGE_DIR = GIT_ROOT / 'python' / 'webeyetrack'
+# Resolve paths relative to the installed package directory (not GIT_ROOT) so it works in wheels. importlib.resources might be a better option.
+PACKAGE_DIR = pathlib.Path(__file__).parent
 DEFAULT_CONFIG = PACKAGE_DIR / 'default_config.yaml'
 MODEL_WEIGHTS = PACKAGE_DIR / 'model_weights'
 FACE_LANDMARKER_PATH = MODEL_WEIGHTS / 'face_landmarker_v2_with_blendshapes.task'

--- a/python/webeyetrack/data_protocols.py
+++ b/python/webeyetrack/data_protocols.py
@@ -128,7 +128,7 @@ class GazeResult:
     gaze_state: Literal['open', 'closed'] = 'open'
 
     # PoG (normalized screen coordinates)
-    norm_pog: np.ndarray = np.array([0.5, 0.5])
+    norm_pog: np.ndarray = field(default_factory=lambda: np.array([0.5, 0.5]))
 
     # Meta data
     durations: dict[str, float] = field(default_factory=dict) # seconds

--- a/python/webeyetrack/webeyetrack.py
+++ b/python/webeyetrack/webeyetrack.py
@@ -1,7 +1,7 @@
 import time
 import pathlib
 from typing import Union, Any, Tuple, Optional, List, Literal
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import random
 
 import tensorflow as tf
@@ -171,8 +171,8 @@ class WebEyeTrackConfig():
     screen_cm_dimensions: Tuple[float, float] = (53.1, 29.8)
     verbose: bool = False
     affine_matrix: Optional[np.ndarray] = None
-    kalman_config: KalmanFilterConfig = KalmanFilterConfig()
-    calib_config: CalibConfig = CalibConfig()
+    kalman_config: KalmanFilterConfig = field(default_factory=lambda: KalmanFilterConfig())
+    calib_config: CalibConfig = field(default_factory=lambda: CalibConfig())
 
 class WebEyeTrack():
 


### PR DESCRIPTION
## Problem

I tried to run the package using Python 3.12. 

I got several errors:

```pytb
  File "webeyetrack/webeyetrack.py", line 7, in <module>
    import tensorflow as tf
ModuleNotFoundError: No module named 'tensorflow'
```

```pytb
  File "webeyetrack/data_protocols.py", line 110, in <module>
    @dataclass
     ^^^^^^^^^
ValueError: mutable default <class 'numpy.ndarray'> for field norm_pog is not allowed: use default_factory
```

```pytb
----> WebEyeTrack(WebEyeTrackConfig())

RuntimeError: Unable to open file at .venv/lib/python3.12/site-packages/webeyetrack/model_weights/face_landmarker_v2_with_blendshapes.task
```

## Solution

1. Add missing tensorflow dependency

2. In dataclasses, mutable default values, such as numpy arrays, are shared across all instances. Since Python 3.11, using them without default_factory or ClassVar results in ValueError. So I've added default_factory.

3. Include model weights in the package (they are small)